### PR TITLE
Added /random/ wrapper unit and its tests

### DIFF
--- a/src/character.rs
+++ b/src/character.rs
@@ -1,0 +1,12 @@
+// character.rs
+use crate::common::Pagination;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CharacterResponse<T> {
+    pub data: T,
+    pub pagination: Option<Pagination>,
+}
+
+
+// to implement

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@ use thiserror::Error;
 pub mod anime;
 pub mod common;
 pub mod manga;
+pub mod random;
+pub mod users;
+pub mod character;
+pub mod people;
 
 const API_BASE_URL: &str = "https://api.jikan.moe/v4";
 

--- a/src/people.rs
+++ b/src/people.rs
@@ -1,0 +1,12 @@
+// people.rs
+use crate::common::Pagination;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeopleResponse<T> {
+    pub data: T,
+    pub pagination: Option<Pagination>,
+}
+
+
+// to implement

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,0 +1,31 @@
+//random.rs
+use crate::{
+  JikanClient, JikanError, anime::*, manga::*, users::*, people::*, character::*, anime::User, anime::Character
+};
+
+impl JikanClient {
+  pub async fn get_random_anime(&self) -> Result<AnimeResponse<Anime>, JikanError> {
+    self.get("/random/anime").await
+  }
+
+  pub async fn get_random_manga(&self) -> Result<MangaResponse<Manga>, JikanError> {
+    self.get("/random/manga").await
+  }
+
+  pub async fn get_random_user(&self) -> Result<UserResponse<User>, JikanError> {
+    self.get("/random/users").await
+  }
+
+  pub async fn get_random_character(&self) -> Result<CharacterResponse<Character>, JikanError> {
+    self.get("/random/characters").await
+  }
+
+  pub async fn get_random_person(&self) -> Result<PeopleResponse<Person>, JikanError> {
+    self.get("/random/people").await
+  }
+
+  pub async fn get_random_people(&self) -> Result<PeopleResponse<Person>, JikanError> { // same as api name
+    self.get("/random/people").await
+  }
+
+}

--- a/src/users.rs
+++ b/src/users.rs
@@ -1,0 +1,89 @@
+//user.rs
+use crate::{
+  common::Pagination,
+  JikanClient, JikanError, anime::User,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserResponse<T> {
+  pub data: T,
+  pub pagination: Option<Pagination>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserVectorResponse<T>{
+  pub data: Vec<T>,
+  pub pagination: Option<Pagination>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserById{
+  pub url:String, 
+  pub username:String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserAnimeInfo{
+  pub days_watched: f32,
+  pub mean_score: f32,
+  pub watching: i32,
+  pub completed: i32,
+  pub on_hold: i32,
+  pub dropped: i32,
+  pub plan_to_watch: i32,
+  pub total_entries: i32,
+  pub rewatched: i32,
+  pub episodes_watched: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserMangaInfo{
+  pub days_read: f32,
+  pub mean_score: f32,
+  pub reading: i32,
+  pub completed: i32,
+  pub on_hold: i32,
+  pub dropped: i32,
+  pub plan_to_read: i32,
+  pub total_entries: i32,
+  pub reread: i32,
+  pub chapters_read: i32,
+  pub volumes_read: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserStats{
+  pub anime: UserAnimeInfo,
+  pub manga: UserMangaInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserStatsResponse{
+  pub data: UserStats,
+  pub pagination: Option<Pagination>,
+}
+
+impl JikanClient {
+  pub async fn get_user_full(&self, username: &str) -> Result<UserResponse<User>, JikanError> {
+    self.get(&format!("/users/{}/full", username)).await
+  }
+
+  pub async fn get_user(&self, username: &str) -> Result<UserResponse<User>, JikanError> {
+    self.get(&format!("/users/{}", username)).await
+  }
+
+  pub async fn get_users(&self) -> Result<UserVectorResponse<User>, JikanError> {
+    self.get(&format!("/users/")).await
+  }
+
+  pub async fn get_user_by_id(&self, id: i32) -> Result<UserResponse<UserById>, JikanError> { //Maybe handle this better?
+    self.get(&format!("/users/userbyid/{}", id)).await
+  }
+
+  pub async fn get_user_stats(&self, username: &str) -> Result<UserStatsResponse, JikanError> {
+    self.get(&format!("/users/{}/statistics", username)).await
+  } 
+}
+
+// to continue

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -1,0 +1,49 @@
+use crate::common::wait_between_tests;
+use jikan_rs::JikanClient;
+use serial_test::serial;
+mod common;
+
+#[tokio::test]
+#[serial]
+async fn get_anime_random() {
+    let client = JikanClient::new();
+    let result = client.get_random_anime().await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_manga_random() {
+    let client = JikanClient::new();
+    let result = client.get_random_manga().await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_user_random() {
+    let client = JikanClient::new();
+    let result = client.get_random_user().await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_character_random() {
+    let client = JikanClient::new();
+    let result = client.get_random_character().await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_person_random() {
+    let client = JikanClient::new();
+    let result = client.get_random_person().await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -7,7 +7,7 @@ mod common;
 #[serial]
 async fn get_user_full(){
     let client = JikanClient::new();
-    let result = client.get_user_full("InSaiyan__").await; // thats me
+    let result = client.get_user_full("InSaiyan__").await; // github.com/In-Saiyan
     assert!(result.is_ok());
     wait_between_tests().await;
 }
@@ -16,7 +16,7 @@ async fn get_user_full(){
 #[serial]
 async fn get_user(){
     let client = JikanClient::new();
-    let result = client.get_user("InSaiyan__").await; // thats me
+    let result = client.get_user("InSaiyan__").await; //  github.com/In-Saiyan
     assert!(result.is_ok());
     wait_between_tests().await;
 }
@@ -43,7 +43,7 @@ async fn get_user_by_id(){
 #[serial]
 async fn get_user_stats(){
     let client = JikanClient::new();
-    let result = client.get_user_stats("InSaiyan__").await; // thats me
+    let result = client.get_user_stats("InSaiyan__").await; //  github.com/In-Saiyan
     assert!(result.is_ok());
     wait_between_tests().await;
 }

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,0 +1,49 @@
+use crate::common::wait_between_tests;
+use jikan_rs::JikanClient;
+use serial_test::serial;
+mod common;
+
+#[tokio::test]
+#[serial]
+async fn get_user_full(){
+    let client = JikanClient::new();
+    let result = client.get_user_full("InSaiyan__").await; // thats me
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_user(){
+    let client = JikanClient::new();
+    let result = client.get_user("InSaiyan__").await; // thats me
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_users(){
+    let client = JikanClient::new();
+    let result = client.get_users().await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_user_by_id(){
+    let client = JikanClient::new();
+    let result = client.get_user_by_id(15847568).await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_user_stats(){
+    let client = JikanClient::new();
+    let result = client.get_user_stats("InSaiyan__").await; // thats me
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}


### PR DESCRIPTION
## Added wrapper for the `/random/` route of jikan API (fixes #7)

The changes consist:
 - `random.rs` - which now returns respective structs fetched through the API
 - `users.rs` - partial implementation of user
 
Note: A lot of code is redundant in `anime.rs` and `manga.rs`, many of the structs are redefined, I left it as it, but now since new files have been made they'd be better suited in that place. (`character.rs`, `people.rs`, `users.rs`), I can fix it if you want me to.

![image](https://github.com/user-attachments/assets/6b2c3ead-cd24-4aa6-90f3-d6d507b2231b)


