### PR TITLE
Added /clubs/ Wrapper unit and its tests

### DIFF
--- a/src/clubs.rs
+++ b/src/clubs.rs
@@ -1,0 +1,138 @@
+// clubs.rs
+use crate::{
+  common::{Images, Pagination},
+  JikanClient, JikanError,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClubResponse<T> {
+  pub data: T,
+  pub pagination: Option<Pagination>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClubVectorResponse<T>{
+  pub data: Vec<T>,
+  pub pagination: Option<Pagination>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Club {
+  pub mal_id: i32, 
+  pub url: String,
+  pub images:  Images,
+  pub name: String,
+  pub members: i32,
+  pub category: String,
+  pub created: String,
+  pub access: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClubMember {
+  pub username: String,
+  pub url: String,
+  pub images: Images,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClubStaff {
+  pub url: String,
+  pub username: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClubRelationContent {
+  pub mal_id: i32,
+  #[serde(rename = "type")]
+  pub type_: String,
+  pub name: String,
+  pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClubRelations {
+  pub anime: Vec<ClubRelationContent>,
+  pub manga: Vec<ClubRelationContent>,
+  pub characters: Vec<ClubRelationContent>,
+}
+
+impl JikanClient {
+  pub async fn get_club_by_id(&self, id: i32) -> Result<ClubResponse<Club>, JikanError> {
+    self.get(&format!("/clubs/{}", id)).await
+  }
+
+  pub async fn get_club_members(&self, id: i32, page: Option<u32>,) -> Result<ClubVectorResponse<ClubMember>, JikanError> {
+    let mut params = Vec::new();
+
+    if let Some(p) = page {
+        params.push(format!("page={}", p));
+    }
+
+    let query = if !params.is_empty() {
+        format!("?{}", params.join("&"))
+    } else {
+        String::new()
+    };
+
+    self.get(&format!("/clubs/{}/members{}", id, query)).await
+  }
+
+  pub async fn get_club_staff(&self, id: i32) -> Result<ClubVectorResponse<ClubStaff>, JikanError> {
+    self.get(&format!("/clubs/{}/staff", id)).await
+  }
+
+  pub async fn get_club_relations(&self, id: i32) -> Result<ClubResponse<ClubRelations>, JikanError> {
+    self.get(&format!("/clubs/{}/relations", id)).await
+  }
+
+  pub async fn get_club_search(
+    &self,
+    page: Option<u32>,
+    limit: Option<u32>,
+    q: Option<String>,
+    category: Option<String>,
+    order_by: Option<String>,
+    sort: Option<String>,
+    letter: Option<String>,
+  ) -> Result<ClubVectorResponse<Club>, JikanError> {
+    let mut params = Vec::new();
+
+    if let Some(p) = page {
+        params.push(format!("page={}", p));
+    }
+
+    if let Some(l) = limit {
+        params.push(format!("limit={}", l));
+    }
+
+    if let Some(qr) = q {
+        params.push(format!("q={}", qr));
+    }
+
+    if let Some(c) = category {
+        params.push(format!("category={}", c));
+    }
+
+    if let Some(ob) = order_by {
+        params.push(format!("order_by={}", ob));
+    }
+
+    if let Some(s) = sort {
+        params.push(format!("sort={}", s));
+    }
+
+    if let Some(lt) = letter {
+        params.push(format!("letter={}", lt));
+    }
+
+    let query = if !params.is_empty() {
+        format!("?{}", params.join("&"))
+    } else {
+        String::new()
+    };
+
+    self.get(&format!("/clubs{}", query)).await
+  } 
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod misc;
 pub mod people;
 pub mod random;
 pub mod users;
+pub mod clubs;
 
 const API_BASE_URL: &str = "https://api.jikan.moe/v4";
 

--- a/tests/clubs.rs
+++ b/tests/clubs.rs
@@ -1,0 +1,103 @@
+use crate::common::wait_between_tests;
+use jikan_rs::{JikanClient, JikanError};
+use serial_test::serial;
+mod common;
+
+#[tokio::test]
+#[serial]
+async fn get_club_by_id() {
+    let client = JikanClient::new();
+    let result = client.get_club_by_id(1).await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_club_members() {
+    let client = JikanClient::new();
+    let result = client.get_club_members(1, Some(1)).await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_club_staff() {
+    let client = JikanClient::new();
+    let result = client.get_club_staff(1).await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_club_relations() {
+    let client = JikanClient::new();
+    let result = client.get_club_relations(1).await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_club_search() {
+    let client = JikanClient::new();
+    let result = client.get_club_search(Some(1), Some(10), Some("anime".to_string()), None, None, None, None).await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_club_search_with_category() {
+    let client = JikanClient::new();
+    let result = client.get_club_search(Some(1), Some(5), None, Some("manga".to_string()), None, None, None).await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_club_search_with_order() {
+    let client = JikanClient::new();
+    let result = client.get_club_search(Some(1), Some(10), None, None, Some("members_count".to_string()), Some("desc".to_string()), None).await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_club_search_with_letter() {
+    let client = JikanClient::new();
+    let result = client.get_club_search(Some(1), Some(10), None, None, None, None, Some("A".to_string())).await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_nonexistent_club() {
+    let client = JikanClient::new();
+    let result = client.get_club_by_id(999999999).await;
+    assert!(matches!(result, Err(JikanError::NotFound)));
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_nonexistent_club_members() {
+    let client = JikanClient::new();
+    let result = client.get_club_members(999999999, Some(1)).await;
+    assert!(matches!(result, Err(JikanError::NotFound)));
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn get_nonexistent_club_staff() {
+    let client = JikanClient::new();
+    let result = client.get_club_staff(999999999).await;
+    assert!(matches!(result, Err(JikanError::NotFound)));
+    wait_between_tests().await;
+}


### PR DESCRIPTION
# Added wrapper for the /clubs/ route of jikan API (fixes #2 )

The changes consist:
- `src/clubs.rs` - which now returns respective structs fetched through the API
- `test/clubs.rs` - contains the tests for clubs.rs

![image](https://github.com/user-attachments/assets/09e95d76-2231-4752-9877-19a23b3eba08)
